### PR TITLE
Fix broken tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       apm-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-python:8000/"]
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-python:3000/"]
       interval: 10s
       retries: 10
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "2.1"
 services:
-  opbeans-python:
+  opbeans-flask:
     build: .
-    image: opbeans-python:latest
+    image: opbeans-flask:latest
     ports:
       - "127.0.0.1:${OPBEANS_PYTHON_PORT:-8000}:3000"
     logging:
@@ -11,7 +11,7 @@ services:
           max-size: '2m'
           max-file: '5'
     environment:
-      - ELASTIC_APM_SERVICE_NAME=${ELASTIC_APM_SERVICE_NAME:-opbeans-python}
+      - ELASTIC_APM_SERVICE_NAME=${ELASTIC_APM_SERVICE_NAME:-opbeans-flask}
       - ELASTIC_APM_SERVER_URL=${ELASTIC_APM_SERVER_URL:-http://apm-server:8200}
       - ELASTIC_APM_JS_SERVER_URL=${ELASTIC_APM_JS_SERVER_URL:-http://localhost:8200}
       - ELASTIC_APM_FLUSH_INTERVAL=5
@@ -31,7 +31,7 @@ services:
       apm-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-python:3000/"]
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-flask:3000/"]
       interval: 10s
       retries: 10
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -5,7 +5,8 @@ load 'test_helper/bats-assert/load'
 load test_helpers
 
 IMAGE="bats-opbeans"
-CONTAINER="opbeans-flask"
+CONTAINER="opbeans-python"
+PORT="8000"
 
 @test "build image" {
 	cd $BATS_TEST_DIRNAME/..
@@ -16,11 +17,6 @@ CONTAINER="opbeans-flask"
 @test "create test container" {
 	run docker-compose up -d
 	assert_success
-}
-
-@test "test container is running" {
-	run docker inspect -f {{.State.Running}} $CONTAINER
-	assert_output --partial 'true'
 }
 
 @test "opbeans is running in port ${PORT}" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -5,7 +5,7 @@ load 'test_helper/bats-assert/load'
 load test_helpers
 
 IMAGE="bats-opbeans"
-CONTAINER="opbeans-python"
+CONTAINER="opbeans-flask"
 PORT="8000"
 
 @test "build image" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -6,6 +6,7 @@ load test_helpers
 
 IMAGE="bats-opbeans"
 CONTAINER="opbeans-flask"
+INTERNAL_PORT="3000"
 PORT="8000"
 
 @test "build image" {
@@ -21,7 +22,7 @@ PORT="8000"
 
 @test "opbeans is running in port ${PORT}" {
 	sleep 50
-	URL="http://127.0.0.1:$(docker port "$CONTAINER" ${PORT} | cut -d: -f2)"
+	URL="http://127.0.0.1:$(docker-compose port "$CONTAINER" ${INTERNAL_PORT} | cut -d: -f2)"
 	run curl -v --fail --connect-timeout 10 --max-time 30 "${URL}/"
 	assert_success
 	assert_output --partial 'HTTP/1.1 200'


### PR DESCRIPTION
This fixes failures seen here:

https://apm-ci.elastic.co/job/apm-agent-python/job/opbeans-flask-mbp/job/master/6/console

Specifically, this:

* Sets the HEALTHCHECK port correctly, which fixes the container being listed as `unhealthy`
* Provides the correct name for the container
* Removes a test which is redundant (since the test immediately after tests the same service)

Test output with changes:
```
❯ make test
12-alpine: Pulling from library/node
Digest: sha256:1660c1b9d3fd9711eb9936e66d4656954cd14b0d2b23a2185c39587dad0239b4
Status: Image is up to date for node:12-alpine
docker.io/library/node:12-alpine
Synchronizing submodule url for 'tests/test_helper/bats-assert'
Synchronizing submodule url for 'tests/test_helper/bats-support'
Tests are in progress, please be patient
1..4
ok 1 build image
ok 2 create test container
ok 3 opbeans is running in port 8000
ok 4 clean test containers
/usr/local/bin/tap-xunit -> /usr/local/lib/node_modules/tap-xunit/bin/tap-xunit
/usr/local/bin/txunit -> /usr/local/lib/node_modules/tap-xunit/bin/tap-xunit
+ tap-xunit@2.4.1
added 21 packages from 21 contributors in 2.563s
```